### PR TITLE
Fixed two broken links to keptn.sh/docs

### DIFF
--- a/site/tutorials/keptn-full-tour-dynatrace-07/index.html
+++ b/site/tutorials/keptn-full-tour-dynatrace-07/index.html
@@ -52,7 +52,7 @@
       </google-codelab-step>
     
       <google-codelab-step label="Bring your own Kubernetes cluster" duration="0">
-        <p>Keptn can be installed on a variety of Kubernetes distributions. Please find a full compatibility matrix for supported Kubernetes versions <a href="https://keptn.sh/docs/0.7.x/installation/k8s-support/" target="_blank">here</a>.</p>
+        <p>Keptn can be installed on a variety of Kubernetes distributions. Please find a full compatibility matrix for supported Kubernetes versions <a href="https://keptn.sh/docs/0.7.x/operate/k8s_support/" target="_blank">here</a>.</p>
 <p>Please find tutorials <a href="../../?cat=installation" target="_blank">how to set up your cluster here</a>.</p>
 <aside class="special"><p>Please note that if you are following one of the installation tutorials, only steps ①-③ are needed (setup of cluster) since we are going to install Keptn as part of this tutorial.</p>
 </aside>

--- a/site/tutorials/keptn-full-tour-prometheus-07/index.html
+++ b/site/tutorials/keptn-full-tour-prometheus-07/index.html
@@ -51,7 +51,7 @@
       </google-codelab-step>
     
       <google-codelab-step label="Bring your own Kubernetes cluster" duration="0">
-        <p>Keptn can be installed on a variety of Kubernetes distributions. Please find a full compatibility matrix for supported Kubernetes versions <a href="https://keptn.sh/docs/0.7.x/installation/k8s-support/" target="_blank">here</a>.</p>
+        <p>Keptn can be installed on a variety of Kubernetes distributions. Please find a full compatibility matrix for supported Kubernetes versions <a href="https://keptn.sh/docs/0.7.x/operate/k8s_support/" target="_blank">here</a>.</p>
 <p>Please find tutorials <a href="../../?cat=installation" target="_blank">how to set up your cluster here</a>.</p>
 <aside class="special"><p>Please note that if you are following one of the installation tutorials, only steps ①-③ are needed (setup of cluster) since we are going to install Keptn as part of this tutorial.</p>
 </aside>

--- a/site/tutorials/keptn-installation-aks-07/index.html
+++ b/site/tutorials/keptn-installation-aks-07/index.html
@@ -55,7 +55,7 @@
 </ul>
 </li>
 </ol>
-<p>Find a full compatibility matrix for supported Kubernetes versions <a href="https://keptn.sh/docs/0.7.x/installation/k8s-support/" target="_blank">here</a>.</p>
+<p>Find a full compatibility matrix for supported Kubernetes versions <a href="https://keptn.sh/docs/0.7.x/operate/k8s_support/" target="_blank">here</a>.</p>
 
 
       </google-codelab-step>
@@ -155,7 +155,7 @@ Successfully authenticated
 <pre><code>keptn configure bridge --output
 </code></pre>
 <p class="image-container"><img alt="empty bridge" src="img/6f96567a81c6b3cf.png"></p>
-<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/keptnsbridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
+<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/bridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
 </aside>
 <h2 is-upgraded>Keptn API</h2>
 <p>Besides the Keptn&#39;s Bridge, please consider also taking a look at the Keptn API endpoint if you are interested to interact with Keptn via the API. Keptn comes with a fully documented swagger-API that can be found under the <code>/api</code> endpoint.</p>

--- a/site/tutorials/keptn-installation-eks-07/index.html
+++ b/site/tutorials/keptn-installation-eks-07/index.html
@@ -58,7 +58,7 @@
 </ul>
 </li>
 </ol>
-<p>Find a full compatibility matrix for supported Kubernetes versions <a href="https://keptn.sh/docs/0.7.x/installation/k8s-support/" target="_blank">here</a>.</p>
+<p>Find a full compatibility matrix for supported Kubernetes versions <a href="https://keptn.sh/docs/0.7.x/operate/k8s_support/" target="_blank">here</a>.</p>
 
 
       </google-codelab-step>
@@ -158,7 +158,7 @@ Successfully authenticated
 <pre><code>keptn configure bridge --output
 </code></pre>
 <p class="image-container"><img alt="empty bridge" src="img/6f96567a81c6b3cf.png"></p>
-<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/keptnsbridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
+<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/bridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
 </aside>
 <h2 is-upgraded>Keptn API</h2>
 <p>Besides the Keptn&#39;s Bridge, please consider also taking a look at the Keptn API endpoint if you are interested to interact with Keptn via the API. Keptn comes with a fully documented swagger-API that can be found under the <code>/api</code> endpoint.</p>

--- a/site/tutorials/keptn-installation-eks/index.html
+++ b/site/tutorials/keptn-installation-eks/index.html
@@ -158,7 +158,7 @@ Successfully authenticated
 <pre><code>keptn configure bridge --output
 </code></pre>
 <p class="image-container"><img alt="empty bridge" src="img/6f96567a81c6b3cf.png"></p>
-<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/keptnsbridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
+<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/bridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
 </aside>
 <h2 is-upgraded>Keptn API</h2>
 <p>Besides the Keptn&#39;s Bridge, please consider also taking a look at the Keptn API endpoint if you are interested to interact with Keptn via the API. Keptn comes with a fully documented swagger-API that can be found under the <code>/api</code> endpoint.</p>

--- a/site/tutorials/keptn-installation-gke-07/index.html
+++ b/site/tutorials/keptn-installation-gke-07/index.html
@@ -168,7 +168,7 @@ Successfully authenticated
 <pre><code>keptn configure bridge --output
 </code></pre>
 <p class="image-container"><img alt="empty bridge" src="img/6f96567a81c6b3cf.png"></p>
-<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/keptnsbridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
+<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/bridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
 </aside>
 <h2 is-upgraded>Keptn API</h2>
 <p>Besides the Keptn&#39;s Bridge, please consider also taking a look at the Keptn API endpoint if you are interested to interact with Keptn via the API. Keptn comes with a fully documented swagger-API that can be found under the <code>/api</code> endpoint.</p>

--- a/site/tutorials/keptn-installation-k3s-07/index.html
+++ b/site/tutorials/keptn-installation-k3s-07/index.html
@@ -155,7 +155,7 @@ Successfully authenticated
 <pre><code>keptn configure bridge --output
 </code></pre>
 <p class="image-container"><img alt="empty bridge" src="img/6f96567a81c6b3cf.png"></p>
-<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/keptnsbridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
+<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/bridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
 </aside>
 <h2 is-upgraded>Keptn API</h2>
 <p>Besides the Keptn&#39;s Bridge, please consider also taking a look at the Keptn API endpoint if you are interested to interact with Keptn via the API. Keptn comes with a fully documented swagger-API that can be found under the <code>/api</code> endpoint.</p>

--- a/site/tutorials/keptn-installation-minikube-07/index.html
+++ b/site/tutorials/keptn-installation-minikube-07/index.html
@@ -155,7 +155,7 @@ Successfully authenticated
 <pre><code>keptn configure bridge --output
 </code></pre>
 <p class="image-container"><img alt="empty bridge" src="img/6f96567a81c6b3cf.png"></p>
-<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/keptnsbridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
+<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/bridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
 </aside>
 <h2 is-upgraded>Keptn API</h2>
 <p>Besides the Keptn&#39;s Bridge, please consider also taking a look at the Keptn API endpoint if you are interested to interact with Keptn via the API. Keptn comes with a fully documented swagger-API that can be found under the <code>/api</code> endpoint.</p>

--- a/site/tutorials/keptn-installation-openshift-07/index.html
+++ b/site/tutorials/keptn-installation-openshift-07/index.html
@@ -192,7 +192,7 @@ Successfully authenticated
 <pre><code>keptn configure bridge --output
 </code></pre>
 <p class="image-container"><img alt="empty bridge" src="img/6f96567a81c6b3cf.png"></p>
-<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/keptnsbridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
+<aside class="special"><p>We are frequently providing early access versions of the Keptn&#39;s Bridge with new functionality - <a href="https://keptn.sh/docs/0.7.x/reference/bridge/#early-access-version-of-keptn-s-bridge" target="_blank">learn more here</a>!</p>
 </aside>
 <h2 is-upgraded>Keptn API</h2>
 <p>Besides the Keptn&#39;s Bridge, please consider also taking a look at the Keptn API endpoint if you are interested to interact with Keptn via the API. Keptn comes with a fully documented swagger-API that can be found under the <code>/api</code> endpoint.</p>

--- a/site/tutorials/keptn-upscaling-dynatrace-07/index.html
+++ b/site/tutorials/keptn-upscaling-dynatrace-07/index.html
@@ -43,7 +43,7 @@
       </google-codelab-step>
     
       <google-codelab-step label="Bring your own Kubernetes cluster" duration="0">
-        <p>Keptn can be installed on a variety of Kubernetes distributions. Please find a full compatibility matrix for supported Kubernetes versions <a href="https://keptn.sh/docs/0.7.x/installation/k8s-support/" target="_blank">here</a>.</p>
+        <p>Keptn can be installed on a variety of Kubernetes distributions. Please find a full compatibility matrix for supported Kubernetes versions <a href="https://keptn.sh/docs/0.7.x/operate/k8s_support/" target="_blank">here</a>.</p>
 <p>Please find tutorials <a href="../../?cat=installation" target="_blank">how to set up your cluster here</a>.</p>
 <aside class="special"><p>Please note that if you are following one of the installation tutorials, only steps ①-③ are needed (setup of cluster) since we are going to install Keptn as part of this tutorial.</p>
 </aside>

--- a/site/tutorials/snippets/07/install/cluster.md
+++ b/site/tutorials/snippets/07/install/cluster.md
@@ -1,6 +1,6 @@
 ## Bring your own Kubernetes cluster
 
-Keptn can be installed on a variety of Kubernetes distributions. Please find a full compatibility matrix for supported Kubernetes versions [here](https://keptn.sh/docs/0.7.x/installation/k8s-support/).
+Keptn can be installed on a variety of Kubernetes distributions. Please find a full compatibility matrix for supported Kubernetes versions [here](https://keptn.sh/docs/0.7.x/operate/k8s_support/).
 
 Please find tutorials [how to set up your cluster here](../../?cat=installation).
 

--- a/site/tutorials/snippets/07/install/open-bridge.md
+++ b/site/tutorials/snippets/07/install/open-bridge.md
@@ -16,7 +16,7 @@ keptn configure bridge --output
 ![empty bridge](./assets/bridge-empty.png)
 
 Positive
-: We are frequently providing early access versions of the Keptn's Bridge with new functionality - [learn more here](https://keptn.sh/docs/0.7.x/reference/keptnsbridge/#early-access-version-of-keptn-s-bridge)!
+: We are frequently providing early access versions of the Keptn's Bridge with new functionality - [learn more here](https://keptn.sh/docs/0.7.x/reference/bridge/#early-access-version-of-keptn-bridge)!
 
 ### Keptn API
 


### PR DESCRIPTION
This PR fixes two broken links:
- https://keptn.sh/docs/0.7.x/installation/k8s-support/ --> https://keptn.sh/docs/0.7.x/operate/k8s_support/
- https://keptn.sh/docs/0.7.x/installation/k8s-support/ --> https://keptn.sh/docs/0.7.x/operate/k8s_support/