### PR TITLE
Replacing dead link

### DIFF
--- a/site/tutorials/snippets/07/quality-gates/setupQualityGate.md
+++ b/site/tutorials/snippets/07/quality-gates/setupQualityGate.md
@@ -2,7 +2,7 @@
 ## Set up the quality gate
 Duration: 4:00
 
-Keptn requires a performance specification for the quality gate. This specification is described in a file called `slo.yaml`, which specifies a Service Level Objective (SLO) that should be met by a service. To learn more about the *slo.yaml* file, go to [Specifications for Site Reliability Engineering with Keptn](https://github.com/keptn/spec/blob/master/sre.md).
+Keptn requires a performance specification for the quality gate. This specification is described in a file called `slo.yaml`, which specifies a Service Level Objective (SLO) that should be met by a service. To learn more about the *slo.yaml* file, go to [Specifications for Site Reliability Engineering with Keptn](https://github.com/keptn/spec/blob/master/service_level_objective.md).
 
 Activate the quality gates for the carts service. Therefore, navigate to the `examples/onboarding-carts` folder and upload the `slo-quality-gates.yaml` file using the [add-resource](https://keptn.sh/docs/0.7.x/reference/cli/commands/keptn_add-resource/) command:
 


### PR DESCRIPTION
Replacing a dead link. This file has actually been removed from the repo, so pointing to an old version is required.