### PR TITLE
Update examples to use the 0.7.2 release branch

### DIFF
--- a/site/tutorials/snippets/07/manage/createProject.md
+++ b/site/tutorials/snippets/07/manage/createProject.md
@@ -9,7 +9,7 @@ To get all files you need for this tutorial, please clone the example repo to yo
 <!-- command -->
 
 ```
-git clone --branch release-0.7.0 https://github.com/keptn/examples.git --single-branch
+git clone --branch release-0.7.2 https://github.com/keptn/examples.git --single-branch
 
 cd examples/onboarding-carts
 ```


### PR DESCRIPTION
We're using the 0.7.0 examples in the tutorial.

![Screenshot from 2020-10-07 14-38-09](https://user-images.githubusercontent.com/56065213/95332094-3e256500-08ab-11eb-9e99-3810ac010f59.png)

Please note that there have been several changes between 0.7.0 and 0.7.2, which you can double-check here: https://github.com/keptn/examples/compare/release-0.7.0...release-0.7.2
I'm not sure if any of these changes affect the tutorial.

This PR changes it to use the 0.7.2 examples.