### PR TITLE
#118 Updated istio version from 1.6.14 to 1.8.2 in installation guide

### DIFF
--- a/site/tutorials/snippets/07/install/istio.md
+++ b/site/tutorials/snippets/07/install/istio.md
@@ -6,25 +6,24 @@ Download the Istio command line tool by [following the official instructions](ht
 
 <!-- command -->
 ```
-curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.14 sh -
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.8.2 sh -
 ```
 
 Check the version of Istio that has been downloaded and execute the installer from the corresponding folder, e.g.,
 
 
-<!-- bash ./istio-1.6.14/bin/istioctl install -y -->
+<!-- bash ./istio-1.8.2/bin/istioctl install -y -->
 
 ```
-./istio-1.6.14/bin/istioctl install
+./istio-1.8.2/bin/istioctl install
 ```
 
 The installation of Istio should be finished within a couple of minutes.
 
 ```
-This will install the default Istio profile into the cluster. Proceed? (y/N) y
+This will install the Istio default profile with ["Istio core" "Istiod" "Ingress gateways"] components into the cluster. Proceed? (y/N) y
 ✔ Istio core installed
 ✔ Istiod installed
 ✔ Ingress gateways installed
-✔ Addons installed
 ✔ Installation complete
 ```


### PR DESCRIPTION
`Istio 1.6.14` has reached its "End of Life" and therefore needs to be replaced with a newer version.

## Fixes Issue
#118 