### PR TITLE
keptn-argo-cd-deployment: Fix the link to "Git-based upstream" document

### DIFF
--- a/site/tutorials/keptn-argo-integration-07.md
+++ b/site/tutorials/keptn-argo-integration-07.md
@@ -77,7 +77,7 @@ stages:
     test_strategy: "performance"
 ```
 
-Create a new project for your services using the `keptn create project` command. In this tutorial, the project is called *sockshop*. The Git user (`--git-user`), an access token (`--git-token`), and the remote URL (`--git-remote-url`) are required for configuring an upstream. For details, please visit [select Git-based upstream](https://keptn.sh/docs/0.7.x/manage/project/#select-git-based-upstream) where instructions for GitHub, GitLab, and Bitbucket are provided. 
+Create a new project for your services using the `keptn create project` command. In this tutorial, the project is called *sockshop*. The Git user (`--git-user`), an access token (`--git-token`), and the remote URL (`--git-remote-url`) are required for configuring an upstream. For details, please visit [Git-based upstream](https://keptn.sh/docs/0.7.x/manage/git_upstream/) where instructions for GitHub, GitLab, and Bitbucket are provided. 
 Before executing the following command, make sure you are in the `examples/onboarding-carts` folder:
 
 ```


### PR DESCRIPTION
Hello Keptn team! This is my first contribution to the Keptn.🙂 

This PR fixes a link in this page of the ArgoCD tutorial: [Argo CD for Deploying and Keptn for Testing, Evaluating, and Promoting](https://tutorials.keptn.sh/tutorials/keptn-argo-cd-deployment-07/index.html#3).

This link was moved to another page by this PR (https://github.com/keptn/keptn.github.io/pull/514). This PR changes the target to the new page of the documentation.