### PR TITLE
Use keptn namespace for Prometheus port-forward

### DIFF
--- a/site/tutorials/snippets/08/monitoring/setupPrometheus.md
+++ b/site/tutorials/snippets/08/monitoring/setupPrometheus.md
@@ -32,7 +32,7 @@ After creating a project and service, you can setup Prometheus monitoring and co
 * To verify that the Prometheus scrape jobs are correctly set up, you can access Prometheus by enabling port-forwarding for the prometheus-service:
 
     ```
-    kubectl port-forward svc/prometheus-service 8080 -n monitoring
+    kubectl port-forward svc/prometheus-service 8080 -n keptn
     ```
 
 Prometheus is then available on [localhost:8080/targets](http://localhost:8080/targets) where you can see the targets for the service:


### PR DESCRIPTION
Following the instructions (copy and pasting shell commands), Prometheus is deployed into my `keptn` namespace and not `monitoring`, so the `port-forward` example does not work as is.

```console
$ kubectl port-forward svc/prometheus-service 8080 -n monitoring
Error from server (NotFound): services "prometheus-service" not found

$ kubectl port-forward svc/prometheus-service 8080 -n keptn
Forwarding from 127.0.0.1:8080 -> 8080
Forwarding from [::1]:8080 -> 8080

$ k get svc -n keptn
NAME                    TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                                                 AGE
keptn-nats-cluster      ClusterIP   None            <none>        4222/TCP,6222/TCP,8222/TCP,7777/TCP,7422/TCP,7522/TCP   10h
shipyard-controller     ClusterIP   10.43.13.84     <none>        8080/TCP                                                10h
mongodb-datastore       ClusterIP   10.43.248.215   <none>        8080/TCP                                                10h
lighthouse-service      ClusterIP   10.43.30.162    <none>        8080/TCP                                                10h
helm-service            ClusterIP   10.43.176.17    <none>        8080/TCP                                                10h
configuration-service   ClusterIP   10.43.247.140   <none>        8080/TCP                                                10h
remediation-service     ClusterIP   10.43.245.80    <none>        8080/TCP                                                10h
bridge                  ClusterIP   10.43.203.217   <none>        8080/TCP                                                10h
mongodb                 ClusterIP   10.43.116.86    <none>        27017/TCP                                               10h
api-gateway-nginx       ClusterIP   10.43.140.46    <none>        80/TCP                                                  10h
approval-service        ClusterIP   10.43.179.57    <none>        8080/TCP                                                10h
statistics-service      ClusterIP   10.43.74.125    <none>        8080/TCP                                                10h
jmeter-service          ClusterIP   10.43.177.68    <none>        8080/TCP                                                10h
api-service             ClusterIP   10.43.148.247   <none>        8080/TCP                                                10h
prometheus-service      ClusterIP   10.43.229.254   <none>        8080/TCP                                                6m49s
```