### PR TITLE
Improve dynatrace oneagent setup

### DIFF
--- a/site/tutorials/keptn-full-tour-dynatrace-08/codelab.json
+++ b/site/tutorials/keptn-full-tour-dynatrace-08/codelab.json
@@ -1,0 +1,34 @@
+{
+  "environment": "web",
+  "format": "html",
+  "prefix": "https://storage.googleapis.com",
+  "mainga": "UA-133584243-1",
+  "updated": "2021-04-26T10:49:29+02:00",
+  "id": "keptn-full-tour-dynatrace-08",
+  "duration": 104,
+  "title": "Keptn Full Tour on Dynatrace",
+  "authors": "Florian Bacher",
+  "summary": "Take a full tour on Keptn with Dynatrace",
+  "source": "keptn-full-tour-dynatrace-08_gen.md",
+  "theme": "",
+  "status": [
+    "published"
+  ],
+  "category": [
+    "dynatrace",
+    "aks",
+    "eks",
+    "gke",
+    "openshift",
+    "pks",
+    "minikube",
+    "full-tour",
+    "quality-gates",
+    "automated-operations"
+  ],
+  "tags": [
+    "keptn08x"
+  ],
+  "feedback": "https://github.com/keptn/tutorials/tree/master/site/tutorials",
+  "url": "keptn-full-tour-dynatrace-08"
+}

--- a/site/tutorials/snippets/08/monitoring/setupDynatrace.md
+++ b/site/tutorials/snippets/08/monitoring/setupDynatrace.md
@@ -71,8 +71,9 @@ For setting up dynatrace-operator, perform the following steps:
    ![Dynatrace Hub](./assets/dt-hub-kubernetes.png)
 1. Click on Kubernetes, and select **Monitor Kubernetes** at the bottom of the screen
 1. In the following screen, select the Platform, a PaaS and API Token, and the OneAgent installation options.
-   
+
    **Note**: Please make sure to tick *Enable volume storage* if you are on GKE, Anthos, CaaS and PKS.
+
    ![Dynatrace Kubernetes Monitoring](./assets/dt-kubernetes-monitor.png)
 1. Copy the generated code and run it in a terminal/bash
 1. Optional: Verify if all pods in the Dynatrace namespace are running. It might take up to 1-2 minutes for all pods to be up and running.
@@ -101,7 +102,7 @@ For setting up dynatrace-operator, perform the following steps:
     dynatrace-operator-fb56f7f59-pf5sg            1/1     Running   0          1d13h
     ```
 
-    **Note**: In case any pods are crashing with `CrashLoopBackOff` or `Error`, please double check that you ticked *Enable volume storage*. Alternatively, please take a look at [the official troubleshooting guide](https://www.dynatrace.com/support/help/technology-support/cloud-platforms/kubernetes/maintenance/troubleshoot-deployment-and-connectivity/#anchor_deploy).
+    **Note**: In case any pods are crashing with `CrashLoopBackOff` or `Error`, please double check that you ticked *Enable volume storage*. Alternatively, please take a look at [the official OneAgent troubleshooting guide](https://www.dynatrace.com/support/help/technology-support/cloud-platforms/kubernetes/maintenance/troubleshoot-deployment-and-connectivity/#anchor_deploy).
    
 1. Optional: Verify in your Dynatrace Environment under the section *Kubernetes* that your cluster is monitored.
 

--- a/site/tutorials/snippets/08/monitoring/setupDynatrace.md
+++ b/site/tutorials/snippets/08/monitoring/setupDynatrace.md
@@ -70,7 +70,9 @@ For setting up dynatrace-operator, perform the following steps:
 1. Within Dynatrace Hub, search for Kubernetes
    ![Dynatrace Hub](./assets/dt-hub-kubernetes.png)
 1. Click on Kubernetes, and select **Monitor Kubernetes** at the bottom of the screen
-1. In the following screen, select the Platform, a PaaS and API Token, and the oenagent installation options (e.g., for GKE you need to enable volume storage).
+1. In the following screen, select the Platform, a PaaS and API Token, and the OneAgent installation options.
+   
+   **Note**: Please make sure to tick *Enable volume storage* if you are on GKE, Anthos, CaaS and PKS.
    ![Dynatrace Kubernetes Monitoring](./assets/dt-kubernetes-monitor.png)
 1. Copy the generated code and run it in a terminal/bash
 1. Optional: Verify if all pods in the Dynatrace namespace are running. It might take up to 1-2 minutes for all pods to be up and running.
@@ -89,6 +91,18 @@ For setting up dynatrace-operator, perform the following steps:
     oneagent-gc2lc                                1/1     Running   0          35h
     oneagent-w7msm                                1/1     Running   0          35h
     ```
+   
+    Note: If you are on newer versions of OneAgent / Dynatrace Operator, pods might look as follows:
+    ```
+    NAME                                          READY   STATUS    RESTARTS   AGE
+    dynakube-classic-d2ckw                        1/1     Running   0          1d13h
+    dynakube-kubemon-0                            1/1     Running   0          15h
+    dynakube-routing-0                            1/1     Running   0          23h
+    dynatrace-operator-fb56f7f59-pf5sg            1/1     Running   0          1d13h
+    ```
+
+    **Note**: In case any pods are crashing with `CrashLoopBackOff` or `Error`, please double check that you ticked *Enable volume storage*. Alternatively, please take a look at [the official troubleshooting guide](https://www.dynatrace.com/support/help/technology-support/cloud-platforms/kubernetes/maintenance/troubleshoot-deployment-and-connectivity/#anchor_deploy).
+   
 1. Optional: Verify in your Dynatrace Environment under the section *Kubernetes* that your cluster is monitored.
 
 ## Install Dynatrace integration
@@ -139,42 +153,3 @@ Since Keptn has configured your Dynatrace tenant, let us take a look what has be
 - *Alerting profile:* An alerting profile with all problems set to *0 minutes* (immediate) is created. You can review this profile by navigating to **Settings > Alerting > Alerting profiles**.
 
 - *Dashboard and Mangement zone:* When creating a new Keptn project or executing the [keptn configure monitoring](https://keptn.sh/docs/0.6.0/reference/cli/commands/keptn_configure_monitoring/) command for a particular project (see Note 1), a dashboard and management zone will be generated reflecting the environment as specified in the shipyard file.
-
-
-Negative
-: If the nodes in your cluster run on *Container-Optimized OS (cos)* (default for GKE), the Dynatrace OneAgent might not work properly, the next steps are necessary. 
-
-Follow the next steps only if your Dynatrace OneAgent does not work properly.
-
-<!-- bash kubectl get pods -n dynatrace -->
-
-1. To check if the OneAgent does not work properly, the output of `kubectl get pods -n dynatrace` might look as follows:
-
-  ```
-  NAME                                           READY   STATUS             RESTARTS   AGE
-  dynatrace-oneagent-operator-7f477bf78d-dgwb6   1/1     Running            0          8m21s
-  oneagent-b22m4                                 0/1     Error              6          8m15s
-  oneagent-k7jn6                                 0/1     CrashLoopBackOff   6          8m15s
-  ```
-
-1. This means that after the initial setup you need to edit the OneAgent custom resource in the Dynatrace namespace and add the following entry to the env section:
-
-        env:
-        - name: ONEAGENT_ENABLE_VOLUME_STORAGE
-          value: "true"
-
-1. To edit the OneAgent custom resource: 
-
-    ```
-    kubectl edit oneagent -n dynatrace
-    ```
-
-
-At the end of your installation, please verify that all Dynatrace resources are in a Ready and Running status by executing `kubectl get pods -n dynatrace`:
-
-```
-NAME                                           READY   STATUS       RESTARTS   AGE
-dynatrace-oneagent-operator-7f477bf78d-dgwb6   1/1     Running      0          8m21s
-oneagent-b22m4                                 1/1     Running      0          8m21s
-oneagent-k7jn6                                 1/1     Running      0          8m21s
-```


### PR DESCRIPTION
Together with @laneli we noticed that the Dynatrace OneAgent installation instructions are outdated and that the note regarding "Enable Volume storage" needs to be more prominent.

This PR fixes those instructions for Keptn 0.8.x.

Preview: https://deploy-preview-156--keptn-tutorials.netlify.app/tutorials/keptn-full-tour-dynatrace-08/index.html?index=..%2F..keptn08x#9 (Step 10)