### PR TITLE
Update unleash and prometheus service to latest versions

### DIFF
--- a/site/tutorials/snippets/08/monitoring/setupPrometheus.md
+++ b/site/tutorials/snippets/08/monitoring/setupPrometheus.md
@@ -19,7 +19,7 @@ helm install prometheus prometheus-community/prometheus --namespace monitoring
 * Download the Keptn's Prometheus service manifest
 <!-- command -->
 ```
-kubectl apply -f  https://raw.githubusercontent.com/keptn-contrib/prometheus-service/release-0.6.0/deploy/service.yaml
+kubectl apply -f  https://raw.githubusercontent.com/keptn-contrib/prometheus-service/release-0.6.1/deploy/service.yaml
 ```
 
 * Replace the environment variable value according to the use case and apply the manifest
@@ -38,7 +38,7 @@ kubectl set env deployment/prometheus-service -n keptn --containers="prometheus-
 * Install Role and Rolebinding to permit Keptn's prometheus-service for performing operations in the Prometheus installed namespace.
 <!-- command -->
 ```
-kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/release-0.6.0/deploy/role.yaml -n monitoring
+kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/prometheus-service/release-0.6.1/deploy/role.yaml -n monitoring
 ```
 
 <!-- 

--- a/site/tutorials/snippets/08/self-healing/featureFlagsDynatrace-crc.md
+++ b/site/tutorials/snippets/08/self-healing/featureFlagsDynatrace-crc.md
@@ -131,7 +131,7 @@ As said, in this tutorial we can use the following command as it is:
     
     <!-- command -->
     ```
-    kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/unleash-service/release-0.3.1/deploy/service.yaml
+    kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/unleash-service/release-0.3.2/deploy/service.yaml
     ```
 
 1. Switch to the carts example (`cd examples/onboarding-carts`) and add the following remediation instructions

--- a/site/tutorials/snippets/08/self-healing/featureFlagsDynatrace.md
+++ b/site/tutorials/snippets/08/self-healing/featureFlagsDynatrace.md
@@ -136,7 +136,7 @@ As said, in this tutorial we can use the following command as it is:
     
     <!-- command -->
     ```
-    kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/unleash-service/release-0.3.1/deploy/service.yaml -n keptn
+    kubectl apply -f https://raw.githubusercontent.com/keptn-contrib/unleash-service/release-0.3.2/deploy/service.yaml -n keptn
     ```
 
 1. Switch to the carts example (`cd examples/onboarding-carts`) and add the following remediation instructions


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Update unleash-service and prometheus-service to latest versions, which should use the keptn/distributor:0.8.4 image.