### PR TITLE
Fix keptn multistage qualitygates tutorial

### DIFF
--- a/site/tutorials/keptn-multistage-qualitygates-09.md
+++ b/site/tutorials/keptn-multistage-qualitygates-09.md
@@ -49,7 +49,7 @@ The demo resources can be found on Github for a convenient experience. Let's clo
 
 <!-- command -->
 ```
-git clone https://github.com/keptn/examples --single-branch
+git clone --branch release-0.9.0 https://github.com/keptn/examples.git --single-branch
 ```
 
 Now, let's switch to the directory including the demo resources.
@@ -129,14 +129,7 @@ In the `shipyard.yaml` shown above, we define two stages called *hardening* and 
 Duration: 2:00
 
 After creating the project, we can continue by onboarding the *helloservice* as a service to your project using the `keptn create service` and `keptn add-resource` commands. You need to pass the project where you want to create the service, as well as the Helm chart of the service.
-For this purpose we need the helm charts as a tar.gz archive. Our repository already contains a tar.gz archive of our helm chart but normally you could use the following command for the conversion:
 
-<!-- command -->
-```
-tar cfvz ./helm/helloservice.tgz ./helm/helloservice
-```
-
-Then the service can be created:
 <!-- command -->
 ```
 keptn create service helloservice --project="podtatohead"
@@ -157,7 +150,7 @@ Lastly before deploying our first build we also need to define the endpoint the 
 
 <!-- command -->
 ```
-keptn add-resource --project=podtatohead --service=helloservice --stage=hardening --resource=helm/endpoints.yaml --resourceUri=helm/endpoints.yaml
+keptn add-resource --project=podtatohead --service=helloservice --all-stages --resource=helm/endpoints.yaml --resourceUri=helm/endpoints.yaml
 ```
 
 ## Deploy first build with Keptn

--- a/site/tutorials/keptn-multistage-qualitygates-09.md
+++ b/site/tutorials/keptn-multistage-qualitygates-09.md
@@ -150,7 +150,8 @@ Lastly before deploying our first build we also need to define the endpoint the 
 
 <!-- command -->
 ```
-keptn add-resource --project=podtatohead --service=helloservice --all-stages --resource=helm/endpoints.yaml --resourceUri=helm/endpoints.yaml
+keptn add-resource --project=$PROJECT --service=$SERVICE --stage=hardening --resource=helm/hardening_endpoints.yaml --resourceUri=helm/endpoints.yaml
+keptn add-resource --project=$PROJECT --service=$SERVICE --stage=production --resource=helm/production_endpoints.yaml --resourceUri=helm/endpoints.yaml
 ```
 
 ## Deploy first build with Keptn

--- a/site/tutorials/keptn-multistage-qualitygates-09.md
+++ b/site/tutorials/keptn-multistage-qualitygates-09.md
@@ -163,12 +163,12 @@ We are now ready to kick off a new deployment of our test application with Keptn
 
     <!-- command -->
     ```
-    keptn trigger delivery --project="podtatohead" --service=helloservice --image="docker.io/jetzlstorfer/helloserver" --tag=0.1.1
+    keptn trigger delivery --project="podtatohead" --service=helloservice --image="ghcr.io/podtato-head/podtatoserver" --tag=v0.1.1
     ```
 
     <!-- bash
     verify_test_step $? "trigger delivery for helloservice failed"
-    wait_for_deployment_with_image_in_namespace "helloservice" "podtatohead-production" "docker.io/jetzlstorfer/helloserver/hello-server:0.1.1"
+    wait_for_deployment_with_image_in_namespace "helloservice" "podtatohead-production" "ghcr.io/podtato-head/podtatoserver:v0.1.1"
     verify_test_step $? "Deployment helloservice not available, exiting..."
     -->
 
@@ -366,12 +366,12 @@ You can now deploy another artifact and see the quality gates in action.
 
 <!-- command -->
 ```
-keptn trigger delivery --project="podtatohead" --service=helloservice --image="docker.io/jetzlstorfer/helloserver" --tag=0.1.1
+keptn trigger delivery --project="podtatohead" --service=helloservice --image="ghcr.io/podtato-head/podtatoserver" --tag=v0.1.1
 ```
 
 <!-- bash 
 verify_test_step $? "trigger delivery for helloservice failed"
-wait_for_deployment_with_image_in_namespace "helloservice" "podtatohead-production" "docker.io/jetzlstorfer/helloserver:0.1.1"
+wait_for_deployment_with_image_in_namespace "helloservice" "podtatohead-production" "ghcr.io/podtato-head/podtatoserver:v0.1.1"
 verify_test_step $? "Deployment helloservice not available, exiting..."
 -->
 
@@ -386,12 +386,12 @@ Duration: 5:00
 
     <!-- command -->
     ```
-    keptn trigger delivery --project="podtatohead" --service=helloservice --image="docker.io/jetzlstorfer/helloserver" --tag=0.1.2
+    keptn trigger delivery --project="podtatohead" --service=helloservice --image="ghcr.io/podtato-head/podtatoserver" --tag=v0.1.2
     ```
 
     <!-- bash 
     verify_test_step $? "trigger delivery for helloservice failed"
-    wait_for_deployment_with_image_in_namespace "helloservice" "podtatohead-hardening" "docker.io/jetzlstorfer/helloserver:0.1.2"
+    wait_for_deployment_with_image_in_namespace "helloservice" "podtatohead-hardening" "ghcr.io/podtato-head/podtatoserver:v0.1.2"
     verify_test_step $? "Deployment helloservice not available, exiting..."
     echo "Waiting for a little bit!"
     wait_for_event_with_field_output "sh.keptn.event.release.finished" ".data.result" "fail" "podtatohead"


### PR DESCRIPTION
Fixing multiple errors in the Keptn multistage quality gates tutorial and switching to a revised version of the podtatohead in the `keptn/examples` repository to avoid version conflicts with the tutorial and the podatohead project.

## Fixes 
#186 