### PR TITLE
fix: Update to prometheus-service 0.8.6 as it includes a bugfix for Keptn 0.17.x

### DIFF
--- a/site/tutorials/snippets/17/monitoring/setupPrometheus.md
+++ b/site/tutorials/snippets/17/monitoring/setupPrometheus.md
@@ -22,7 +22,7 @@ Keptn doesn't install or manage Prometheus and its components. Users need to ins
 * Install prometheus-service using `helm`:
 <!-- command -->
 ```
-helm upgrade --install -n keptn prometheus-service https://github.com/keptn-contrib/prometheus-service/releases/download/0.8.5/prometheus-service-0.8.5.tgz --reuse-values --wait
+helm upgrade --install -n keptn prometheus-service https://github.com/keptn-contrib/prometheus-service/releases/download/0.8.6/prometheus-service-0.8.6.tgz --reuse-values --wait
 ```
 
 <!-- 


### PR DESCRIPTION
Version 0.8.6 of prometheus-service has been released and addresses a problem with self-healing / remediaiton use-case.

https://github.com/keptn-contrib/prometheus-service/releases/tag/0.8.6