### PR TITLE
fix: Istio installation in Full tour on Prometheus 0.17

### DIFF
--- a/site/tutorials/snippets/17/install/istio.md
+++ b/site/tutorials/snippets/17/install/istio.md
@@ -6,7 +6,7 @@ Download the Istio command line tool by [following the official instructions](ht
 
 <!-- command -->
 ```
-curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.14.2
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.14.2 sh -
 ```
 
 Check the version of Istio that has been downloaded and execute the installer from the corresponding folder, e.g.:


### PR DESCRIPTION
## This PR

- Fixes the Istio installation command in the "Full tour on Prometheus" tutorial for Keptn 0.17